### PR TITLE
Add Websocket Benchmark

### DIFF
--- a/websockets.yaml
+++ b/websockets.yaml
@@ -1,0 +1,17 @@
+config:
+  target: ws://0.0.0.0:8545/eth
+  phases:
+    - duration: 30
+      arrivalRate: 20
+      name: Peak Load
+  processor: "./processor.js"
+
+ 
+scenarios:
+  - name: "ETH Call"
+    engine: ws
+    flow:
+      - function: single_call
+      - loop:
+        - send: "{{ query }}"
+        count: 50

--- a/websockets.yaml
+++ b/websockets.yaml
@@ -13,5 +13,10 @@ scenarios:
     flow:
       - function: single_call
       - loop:
-        - send: "{{ query }}"
+        - send:
+            payload: "{{ query }}"
+        #     capture:
+        #       json: "$"
+        #       as: "res"
+        # - log: "Response = {{ res }}"
         count: 50


### PR DESCRIPTION
Adding a benchmark for creating same amount of requests as in the batch and single_call script.

### Benchmarking results 

Setup: dshackle loadbalanced against primary & secondary alchemy node with different API keys

Command: 
```
yarn artillery run single_call.yaml; yarn artillery run batch_call.yaml; yarn artillery run websockets.yaml
```

**Test1**: Dshackle with RPC upstream only

|script|req/sec (target 1k)|success_rate|
|---|---|---|
|single|300|99.98%|
|batch|20 batches (@ 50 calls each) |95%|
|websocket|1060|100%|

While batch is able to produce the desired throughput (1k calls/sec) it has a pretty high failure rate. Single calls are able to succeed reliably but seem to be throttled. Therefore, websocket connections seem promising.

**Test1**: Dshackle with WS+RPC upstream
|script|req/sec (target 1k)|success_rate|
|---|---|---|
|single|48|14.7%|
|batch|20 batches (@ 50 calls each) |2.3%|
|websocket|1060|100%|

Weirdly, turning on upstream ws seems to have a very negative effect on RPC throughput and success rate