### PR TITLE
Record Custom RPC Metrics

### DIFF
--- a/batch_call.yaml
+++ b/batch_call.yaml
@@ -8,8 +8,9 @@ config:
  
 scenarios:
   - name: "ETH Call"
+    beforeRequest: batch_call
+    afterResponse: check_response
     flow:
-      - function: batch_call
       - post:
           url: "/eth"
-          json: "{{ query }}"
+          json: {}

--- a/processor.js
+++ b/processor.js
@@ -1,29 +1,59 @@
-function single_call(context, events, done) {
-  context.vars['query'] = randomCall(1)
-  return done()
+function single_call(req, context, events, next) {
+  req.json = randomCall(1);
+  events.emit("counter", "rpc.requests", 1);
+  return next();
 }
 
-function batch_call(context, events, done) {
-  context.vars['query'] = [...Array(50)].map((_, i) => randomCall(i))
-  return done()
+const BATCH_SIZE = 50;
+
+function batch_call(req, context, events, next) {
+  req.json = [...Array(BATCH_SIZE)].map((_, i) => randomCall(i));
+  events.emit("counter", "rpc.requests", BATCH_SIZE);
+  return next();
 }
 
-const genRanHex = size => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+const genRanHex = (size) =>
+  [...Array(size)]
+    .map(() => Math.floor(Math.random() * 256).toString(16).padStart(2, "0"))
+    .join("");
 
-const randomCall = id => {
+const randomCall = (id) => {
   return {
-    "jsonrpc":"2.0",
-    "method":"eth_call",
-    "params":[
+    "jsonrpc": "2.0",
+    "method": "eth_call",
+    "params": [
       {
-        "data":"0x70a08231000000000000000000000000" + genRanHex(40),
-        "to":"0x4b13006980acb09645131b91d259eaa111eaf5ba"
-      },"latest"],
-    "id": id
+        "data": "0x70a08231000000000000000000000000" + genRanHex(20),
+        "to": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+      },
+      "latest",
+    ],
+    "id": id,
+  };
+};
+
+function check_response(_req, res, _context, events, next) {
+  try {
+    const json = JSON.parse(res.body);
+    const responses = Array.isArray(json) ? json : [json];
+
+    const errors = responses.filter((r) => r.error).length;
+    const success = responses.length - errors;
+
+    responses.forEach(() => events.emit("rate", "rpc.request_rate"));
+    events.emit("counter", "rpc.responses_success", success);
+    events.emit("counter", "rpc.responses_error", errors);
+
+    return next();
+  } catch (err) {
+    console.log(`${err}: ${res.body}`);
+    events.emit("counter", "rpc.invalid_json", 1);
+    return next();
   }
 }
 
 module.exports = {
   single_call,
   batch_call,
-}
+  check_response,
+};

--- a/processor.js
+++ b/processor.js
@@ -43,13 +43,12 @@ function check_response(_req, res, _context, events, next) {
     responses.forEach(() => events.emit("rate", "rpc.request_rate"));
     events.emit("counter", "rpc.responses_success", success);
     events.emit("counter", "rpc.responses_error", errors);
-
-    return next();
   } catch (err) {
     console.log(`${err}: ${res.body}`);
     events.emit("counter", "rpc.invalid_json", 1);
-    return next();
   }
+  
+  return next();
 }
 
 module.exports = {

--- a/single_call.yaml
+++ b/single_call.yaml
@@ -7,10 +7,11 @@ config:
  
 scenarios:
   - name: "ETH Call"
+    beforeRequest: single_call
+    afterResponse: check_response
     flow:
-      - function: single_call
       - loop:
-        - post:
-            url: "/eth"
-            json: "{{ query }}"
+          - post:
+              url: "/eth"
+              json: {}
         count: 50


### PR DESCRIPTION
This PR changes the `artillery` setup to record custom RPC metrics when doing benchmarking. The reason for this change is that I noticed that the recorded results were not checking whether or not the RPC calls actually succeeded (i.e. didn't return a JSON RPC error) but only checking the HTTP status codes. This is insufficient, as Dshackle will (in some cases, and AFAIU it is **correct** JSON RPC behaviour) return something like this with an HTTP 200:

```json
{
  "id": 42,
  "error": { "message": "..." }
}
```

### Test Plan

Run some benchmarks and see cool new metrics:
```
% yarn artillery run batch_call.yaml
...
rpc.request_rate: .............................................................. 1026/sec
rpc.requests: .................................................................. 30000
rpc.responses_error: ........................................................... 720
rpc.responses_success: ......................................................... 29030
...
```

Note that `29030 + 720 != 30000`! This is expected in this case since we _only process successful HTTP responses_, and in the run there were some TCP timeouts.